### PR TITLE
BCN-2508. Handle sequence name containing schema.

### DIFF
--- a/lib/active_record/connection_adapters/postgis/schema_statements.rb
+++ b/lib/active_record/connection_adapters/postgis/schema_statements.rb
@@ -20,7 +20,8 @@ module ActiveRecord
 
           if (match = default_function&.match(/\Anextval\('"?(?<sequence_name>.+_(?<suffix>seq\d*))"?'::regclass\)\z/))
             name_without_schema = table_name.include?('.') ? table_name.split('.')[1] : table_name
-            serial = sequence_name_from_parts(name_without_schema, column_name, match[:suffix]) == match[:sequence_name]
+            sequence_without_schema = match[:sequence_name].include?('.') ? match[:sequence_name].split('.')[1] : match[:sequence_name]
+            serial = sequence_name_from_parts(name_without_schema, column_name, match[:suffix]) == sequence_without_schema
           end
 
           # {:dimension=>2, :has_m=>false, :has_z=>false, :name=>"latlon", :srid=>0, :type=>"GEOMETRY"}

--- a/lib/active_record/connection_adapters/postgis/version.rb
+++ b/lib/active_record/connection_adapters/postgis/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module PostGIS
-      VERSION = "9.1.2"
+      VERSION = "9.1.3"
     end
   end
 end


### PR DESCRIPTION
before:
```
create_table "schema_one.my_table_name", force: :cascade do |t|
   t.string "some_column"
end

create_table "schema_two.my_table_name", id: :bigint, default: -> { "nextval('schema_two.my_table_name_id_seq'::regclass)" }, force: :cascade do |t|
   t.string "some_column"
end
```

after:
```
create_table "schema_one.my_table_name", force: :cascade do |t|
   t.string "some_column"
end

create_table "schema_two.my_table_name", force: :cascade do |t|
   t.string "some_column"
end
```